### PR TITLE
Added using jax numpy for linspace

### DIFF
--- a/gordon/tests/test_gordon.py
+++ b/gordon/tests/test_gordon.py
@@ -2,6 +2,7 @@
 """
 import os
 import numpy as np
+from jax import numpy as jax_np
 from jax import grad as jax_grad
 from jax import vmap as jax_vmap
 from jax import jit as jax_jit
@@ -11,7 +12,7 @@ from ..sigmoid_smhm import _logsm_from_logmhalo_jax_kern
 
 
 NM = int(os.environ.get("GORDON_NM", 500))
-LOGM = np.linspace(8, 15, NM)
+LOGM = jax_np.linspace(8, 15, NM)
 PARAMS = np.array(list(DEFAULT_PARAM_VALUES.values()))
 
 


### PR DESCRIPTION
**Problem:**
When using bigger values for __GORDON_NM__ like 1000000000 initialization time of linspace() is quite huge and it cloud the profiling efforts. So It would be good to speed it up.

**Solution:**
jax.numpy.linspace() is faster across tested devices  (Intel CPU, Intel GPU, Intel XPU) than numpy.linspace(). It will help with more efficient performance profiling of those tests.