### PR TITLE
Introducing sharding 

### DIFF
--- a/gordon/tests/test_gordon.py
+++ b/gordon/tests/test_gordon.py
@@ -6,23 +6,46 @@ from jax import numpy as jax_np
 from jax import grad as jax_grad
 from jax import vmap as jax_vmap
 from jax import jit as jax_jit
+from jax import local_devices
+from jax import local_device_count
+from jax import device_put
+from jax.debug import visualize_array_sharding
+from jax.experimental import mesh_utils
+from jax.sharding import PositionalSharding
 from ..sigmoid_smhm import logsm_from_logmhalo_jax, DEFAULT_PARAM_VALUES
 from ..kernel_weighted_hist import triweighted_kernel_histogram_with_derivs as twhist
 from ..sigmoid_smhm import _logsm_from_logmhalo_jax_kern
 
 
+NUM_DEVICES = int(os.environ.get("DEVICES_NM",  1))     # Number of XPUs to be used 
 NM = int(os.environ.get("GORDON_NM", 500))
-LOGM = jax_np.linspace(8, 15, NM)
+
+if NUM_DEVICES > local_device_count():
+  print("Error: More device("+str(NUM_DEVICES)+") was requested than supported("+str(local_device_count)+")")
+  exit(-1)
+
+if NM % local_device_count():
+  print("Error: GORDON_NM value : "+str(NM)+" cannot be evenly splitted into: "+str(local_device_count())+" devices")
+  exit(-1)
+
+# allocate data on CPU
+LOGM = np.linspace(8, 15, NM)
 PARAMS = np.array(list(DEFAULT_PARAM_VALUES.values()))
 
+# distribute/replicate data on devices
+sharding = PositionalSharding(mesh_utils.create_device_mesh((NUM_DEVICES,),devices=local_devices()[0:NUM_DEVICES]))
+LOGM_DEVICES = device_put(LOGM,sharding.reshape(NUM_DEVICES,))
+PARAMS_DEVICES = device_put(PARAMS,sharding.replicate()) 
+visualize_array_sharding(LOGM_DEVICES)
 
 def test_logsm_from_logmhalo_evaluates():
-    logsm = logsm_from_logmhalo_jax(LOGM, PARAMS)
+
+    logsm = logsm_from_logmhalo_jax(LOGM_DEVICES, PARAMS_DEVICES)
     assert np.all(np.isfinite(logsm))
 
 
 def test_kernel_hist_evaluates():
-    logsm = np.array(logsm_from_logmhalo_jax(LOGM, PARAMS))
+    logsm = np.array(logsm_from_logmhalo_jax(LOGM_DEVICES, PARAMS_DEVICES))
     logsm_bins = np.linspace(10, 11, 10)
     n_halos, n_params = logsm.size, len(PARAMS)
     sigma = 0.25
@@ -35,12 +58,13 @@ def test_kernel_hist_evaluates():
 
 def test_kernel_weighted_hist_of_model_gradients():
     """Compute model gradients with jax and propagate through histogram with numba."""
-    logsm = np.array(logsm_from_logmhalo_jax(LOGM, PARAMS))
+
+    logsm = np.array(logsm_from_logmhalo_jax(LOGM_DEVICES, PARAMS_DEVICES))
     logsm_bins = np.linspace(10, 11, 10)
     scatter = 0.25
     _gradfunc = jax_grad(_logsm_from_logmhalo_jax_kern, argnums=1)
     gradfunc = jax_jit(jax_vmap(_gradfunc, in_axes=(0, None)))
-    smhm_jac = np.array(gradfunc(LOGM, PARAMS))
+    smhm_jac = np.array(gradfunc(LOGM_DEVICES, PARAMS_DEVICES))
     assert np.shape(smhm_jac) == (LOGM.size, len(PARAMS))
 
     h, h_jac = twhist(logsm, smhm_jac, logsm_bins, scatter)

--- a/gordon/tests/test_gordon.py
+++ b/gordon/tests/test_gordon.py
@@ -24,8 +24,8 @@ if NUM_DEVICES > local_device_count():
   print("Error: More device("+str(NUM_DEVICES)+") was requested than supported("+str(local_device_count)+")")
   exit(-1)
 
-if NM % local_device_count():
-  print("Error: GORDON_NM value : "+str(NM)+" cannot be evenly splitted into: "+str(local_device_count())+" devices")
+if NM % NUM_DEVICES:
+  print("Error: GORDON_NM value : "+str(NM)+" cannot be evenly splitted into: "+str(NUM_DEVICES)+" devices")
   exit(-1)
 
 # allocate data on CPU


### PR DESCRIPTION
Hi,

#### Goal: 
- Improve performance of gordon functionalities
-  Allow to use bigger process bigger arrays of data (bigger GORDON_NM)

#### Description:
Those unit tests were updated to demonstrate how sharding can be used for gordon functionalities. It is possible
to point with env var `DEVICES_NM` how many JAX devices are to be used for this unit test.
This PR is demonstration how sharding can be used for gordon workloads

##### Example:
`GORDON_NM=20000100000 DEVICES_NM=10 python -mpytest  -v    -s`

#### Memory:
There is `GORDON_NM` env var which was  mapped into how big array of data will be processed.  
So on master branch this was not possible to execute :
`GORDON_NM=10000002000  python -mpytest  -v    -s -k test_logsm_from_logmhalo_evaluates`
But with this PR we can use more devices and then:
`GORDON_NM=10000002000  DEVICES_NM=4 python -mpytest  -v    -s -k test_logsm_from_logmhalo_evaluates`
 it works.

#### Performance:
Unit tests are not subject for benchmarking so some data were presented on internal chat. Unit test itself is not good for performance tests as multiple operations (asserts, numba are made on CPU).



#### Notes:
- jax.numpy.linespace was replace with numpy.linspace as jax.numpy.linspace is not working properly for bigger GORDON_NM values. 
- `jax.visualize_array_sharding does require` python module: rich 
- performance results presneted on internal chat were taken from performance branch (logsm functionality). Grad also scales but not that well.
- It was tested againt jax & jaxlib 0.4.13 (it crash on 0.4.4)


Please comment and review